### PR TITLE
BYT-580: comprehensive readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,16 @@ Create a [Google Maps API Key](https://developers.google.com/maps/gmp-get-starte
 
 
 ### Simple Implementation
-Install this package
+**Install this package**
 ```bash
 yarn add @gocrisp/react-store-locator
 ```
+or
+```
+npm install @gocrisp/store-locator --save
+```
 
-Include the styles: We have some minimal styles included as plain css in `@gocrisp/react-store-locator/dist/react-store-locator.css`. You will need to pull this into your site however you are including styles. We've kept the definitions as minimal as possible so that you can easily override or recreate the styles yourself. And every class is namespaced with the `map_` prefix to avoid collisions. 
+**Include the styles:** We have some minimal styles included as plain css in `@gocrisp/react-store-locator/dist/react-store-locator.css`. You will need to pull this into your site however you are including styles. We've kept the definitions as minimal as possible so that you can easily override or recreate the styles yourself. And every class is namespaced with the `map_` prefix to avoid collisions. 
 
 Then, wherever you want to include the store locator map, insert this snippet:
 ```jsx


### PR DESCRIPTION
This just mirrors what was updated in the README in https://github.com/gocrisp/store-locator/pull/12. It still needs a link to the support doc.

I considered updating the usage of `createStoreLocatorMap` to allow for the callback function thing, but it's much weirder trying to do that here. It should probably be accomplished completely differently. It's probably not a super common use case so I'm just going to leave it for now.