### PR TITLE
BYT-693: optional pre loading of google maps api

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,8 @@ module.exports = {
     "prettier",
     "testing-library",
     "jest-dom",
-    "import"
+    "import",
+    "react"
   ],
   extends: [
     "eslint:recommended",
@@ -22,7 +23,9 @@ module.exports = {
     "plugin:jest-dom/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:import/typescript"
+    "plugin:import/typescript",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
   ],
   parserOptions: {
     project: "tsconfig.json"
@@ -38,6 +41,12 @@ module.exports = {
     "@typescript-eslint/explicit-function-return-type": ["off"],
     "@typescript-eslint/explicit-member-accessibility": ["off"],
     "@typescript-eslint/no-empty-function": ["off"],
-    "import/order": ["error"]
+    "import/order": ["error"],
+    "react/prop-types": "off"
   },
+  settings: {
+    react: {
+      version: "detect"
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn add @gocrisp/react-store-locator
 ```
 or
 ```bash
-npm install @gocrisp/store-locator --save
+npm install @gocrisp/react-store-locator --save
 ```
 
 **Include the styles:** We have some minimal styles included as plain css in `@gocrisp/react-store-locator/dist/react-store-locator.css`. You will need to pull this into your site however you are including styles. We've kept the definitions as minimal as possible so that you can easily override or recreate the styles yourself. And every class is namespaced with the `map_` prefix to avoid collisions. 

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -10,8 +10,13 @@ const App = () => (
     mapOptions={{ center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 }}
     formatLogoPath={feature =>
       `img/${feature
-        .getProperty('banner')
+        .getProperty('store')
         .toLowerCase()
+        // remove after 2nd space
+        .split(' ')
+        .slice(0, 2)
+        .join('')
+        // remove special characters
         .replace(/[^a-z0-9]/g, '')}.png`
     }
     searchBoxOptions={{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gocrisp/react-store-locator",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "React component for Crisp's store locator widget, intended for use with the Crisp GeoJSON connector.",
   "main": "dist/react-store-locator.js",
   "umd:main": "dist/react-store-locator.umd.js",
@@ -11,7 +11,7 @@
     "readme.md"
   ],
   "dependencies": {
-    "@gocrisp/store-locator": "^0.2.0",
+    "@gocrisp/store-locator": "^0.4.0",
     "@googlemaps/js-api-loader": "^1.11.3"
   },
   "devDependencies": {
@@ -36,6 +36,8 @@
     "eslint-plugin-jest-dom": "^3.6.5",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-react": "^7.23.2",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-testing-library": "^3.10.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.4.2",

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -57,7 +57,7 @@ describe('react-store-locator', () => {
     expect(element).toHaveStyle(style);
   });
 
-  it('position and overflow are constant (cannot be overwritten)', async () => {
+  it('position and overflow are constant (cannot be overwritten)', () => {
     const style = {
       position: 'absolute',
       overflow: 'auto',

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -32,20 +32,20 @@ describe('react-store-locator', () => {
 
   beforeEach(mockCreateStoreLocatorMap);
 
-  it('calls createStoreLocatorMap on render', async () => {
+  it('calls createStoreLocatorMap on render', () => {
     render(<StoreLocator onMapInit={jest.fn} {...options} />);
     expect(createStoreLocatorMap).toHaveBeenCalledTimes(1);
     // @ts-expect-error Tuple of type [] has no matching index 0
     expect(createStoreLocatorMap.mock.calls[0][0]).toMatchObject(options);
   });
 
-  it('includes classNames on container', async () => {
+  it('includes classNames on container', () => {
     const className = 'cls1 cls2 cls3';
     render(<StoreLocator onMapInit={jest.fn} {...options} className={className} />);
     expect(document.getElementsByClassName(className)?.length).toBe(1);
   });
 
-  it('includes style properties on container', async () => {
+  it('includes style properties on container', () => {
     const style = {
       overflow: 'hidden',
       backgroundColor: 'red',

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import { createStoreLocatorMap } from '@gocrisp/store-locator';
 import { render, waitFor } from '@testing-library/react';
-import { Loader } from '@googlemaps/js-api-loader';
 import '@testing-library/jest-dom';
-import { mocked } from 'ts-jest/utils';
 import { StoreLocator } from '../index';
 
 jest.mock('@gocrisp/store-locator');
-
-jest.mock('@googlemaps/js-api-loader');
-const mockLoader = mocked(Loader, true);
 
 const options = {
   loaderOptions: { apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk' },
@@ -28,8 +23,6 @@ const options = {
 };
 
 describe('react-store-locator', () => {
-  const onMapInit = jest.fn();
-
   const resolveCreateValue = 14;
   const mockCreateStoreLocatorMap = () => {
     const fn = jest.fn(() => Promise.resolve(resolveCreateValue));
@@ -38,17 +31,9 @@ describe('react-store-locator', () => {
   };
 
   beforeEach(mockCreateStoreLocatorMap);
-  beforeEach(() => {
-    // @ts-expect-error: not mocking the whole thing
-    mockLoader.mockImplementation(() => ({ load: () => Promise.resolve() }));
-
-    onMapInit.mockReset();
-  });
 
   it('calls createStoreLocatorMap on render', async () => {
-    render(<StoreLocator onMapInit={onMapInit} {...options} />);
-    await waitFor(() => onMapInit.mock.calls.length > 0);
-
+    render(<StoreLocator onMapInit={jest.fn} {...options} />);
     expect(createStoreLocatorMap).toHaveBeenCalledTimes(1);
     // @ts-expect-error Tuple of type [] has no matching index 0
     expect(createStoreLocatorMap.mock.calls[0][0]).toMatchObject(options);
@@ -57,8 +42,6 @@ describe('react-store-locator', () => {
   it('includes classNames on container', async () => {
     const className = 'cls1 cls2 cls3';
     render(<StoreLocator onMapInit={jest.fn} {...options} className={className} />);
-    await waitFor(() => onMapInit.mock.calls.length > 0);
-
     expect(document.getElementsByClassName(className)?.length).toBe(1);
   });
 
@@ -70,8 +53,6 @@ describe('react-store-locator', () => {
     const className = 'store-locator';
     render(<StoreLocator onMapInit={jest.fn} {...options} style={style} className={className} />);
 
-    await waitFor(() => onMapInit.mock.calls.length > 0);
-
     const element = document.getElementsByClassName(className)[0];
     expect(element).toHaveStyle(style);
   });
@@ -82,15 +63,14 @@ describe('react-store-locator', () => {
       overflow: 'auto',
     } as React.CSSProperties;
     const className = 'store-locator';
-
     render(<StoreLocator onMapInit={jest.fn} {...options} style={style} className={className} />);
-    await waitFor(() => onMapInit.mock.calls.length > 0);
 
     const element = document.getElementsByClassName(className)[0];
     expect(element).toHaveStyle({ position: 'relative', overflow: 'hidden' });
   });
 
   it('calls onMapInit on initialisation', async () => {
+    const onMapInit = jest.fn();
     render(<StoreLocator onMapInit={onMapInit} {...options} />);
     await waitFor(() => onMapInit.mock.calls.length > 0);
     expect(onMapInit).toHaveBeenCalledTimes(1);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   createStoreLocatorMap,
   StoreLocatorMap,
@@ -6,7 +6,6 @@ import {
 } from '@gocrisp/store-locator';
 
 import '@gocrisp/store-locator/dist/store-locator.css';
-import { Loader } from '@googlemaps/js-api-loader';
 
 export type StoreLocatorProps = Omit<StoreLocatorOptions, 'container'> & {
   className?: string;
@@ -24,26 +23,11 @@ export const StoreLocator: React.VFC<StoreLocatorProps> = ({
   infoWindowOptions,
   formatLogoPath,
   searchBoxOptions,
-  skipLoadingGoogleMaps,
 }) => {
-  const [mapsLibraryLoaded, setMapsLibraryLoaded] = useState(skipLoadingGoogleMaps);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!skipLoadingGoogleMaps) {
-      const loader = new Loader({
-        apiKey: loaderOptions.apiKey,
-        libraries: ['places', 'geometry'],
-      });
-      loader
-        .load()
-        .then(() => setMapsLibraryLoaded(true))
-        .catch(err => console.error('Could not load Google Maps', err));
-    }
-  }, [loaderOptions.apiKey, skipLoadingGoogleMaps]);
-
-  useEffect(() => {
-    if (containerRef.current && mapsLibraryLoaded) {
+    if (containerRef.current) {
       createStoreLocatorMap({
         container: containerRef.current,
         loaderOptions,
@@ -52,13 +36,11 @@ export const StoreLocator: React.VFC<StoreLocatorProps> = ({
         infoWindowOptions,
         formatLogoPath,
         searchBoxOptions,
-        skipLoadingGoogleMaps: true,
       })
         .then(onMapInit)
         .catch(err => console.error('Could not initialize store locator map.', err));
     }
   }, [
-    mapsLibraryLoaded,
     loaderOptions,
     geoJson,
     formatLogoPath,

--- a/static/sample.json
+++ b/static/sample.json
@@ -7,9 +7,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Patisserie",
-              "name": "Mayfair",
-              "formattedAddress": "The Vestry, 2A Mill St, Mayfair, London W1S 1FX, UK"
+              "store": "Josie's Patisserie Mayfair",
+              "storeFullAddress": "The Vestry, 2A Mill St, Mayfair, London W1S 1FX, UK"
           }
       },
       {
@@ -19,9 +18,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Patisserie",
-              "name": "Bristol",
-              "formattedAddress": "Linear Park, Bristol, UK"
+              "store": "Josie's Patisserie Bristol",
+              "storeFullAddress": "Linear Park, Bristol, UK"
           }
       },
       {
@@ -31,9 +29,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Patisserie",
-              "name": "Norwich",
-              "formattedAddress": "140 Armes St, Norwich NR2 4EA, UK"
+              "store": "Josie's Patisserie Norwich",
+              "storeFullAddress": "140 Armes St, Norwich NR2 4EA, UK"
           }
       },
       {
@@ -43,9 +40,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Patisserie",
-              "name": "Wimborne",
-              "formattedAddress": "2 Three Lions Cl, Wimborne BH21 1EP, UK"
+              "store": "Josie's Patisserie Wimborne",
+              "storeFullAddress": "2 Three Lions Cl, Wimborne BH21 1EP, UK"
           }
       },
       {
@@ -55,9 +51,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Patisserie",
-              "name": "Liverpool",
-              "formattedAddress": "106 Dale St, Liverpool L2 4TQ, United Kingdom"
+              "store": "Josie's Patisserie Liverpool",
+              "storeFullAddress": "106 Dale St, Liverpool L2 4TQ, United Kingdom"
           }
       },
       {
@@ -67,9 +62,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Patisserie",
-              "name": "Tamworth",
-              "formattedAddress": "Saxon Mill Ln, Tamworth B79 7JJ, UK"
+              "store": "Josie's Patisserie Tamworth",
+              "storeFullAddress": "Saxon Mill Ln, Tamworth B79 7JJ, UK"
           }
       },
       {
@@ -79,9 +73,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Patisserie",
-              "name": "Cardiff",
-              "formattedAddress": "128 E Tyndall St, Cardiff CF24 5EX, UK"
+              "store": "Josie's Patisserie Cardiff",
+              "storeFullAddress": "128 E Tyndall St, Cardiff CF24 5EX, UK"
           }
       },
       {
@@ -91,9 +84,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Cafe",
-              "name": "Oakham",
-              "formattedAddress": "B640, Oakham LE15 6HW, UK"
+              "store": "Josie's Cafe Oakham",
+              "storeFullAddress": "B640, Oakham LE15 6HW, UK"
           }
       },
       {
@@ -103,9 +95,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Cafe",
-              "name": "Blackburn",
-              "formattedAddress": "Blackburn, UK"
+              "store": "Josie's Cafe Blackburn",
+              "storeFullAddress": "Blackburn, UK"
           }
       },
       {
@@ -115,9 +106,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Cafe",
-              "name": "Crawley",
-              "formattedAddress": "124 Buckswood Dr, Crawley RH11 8JA, UK"
+              "store": "Josie's Cafe Crawley",
+              "storeFullAddress": "124 Buckswood Dr, Crawley RH11 8JA, UK"
           }
       },
       {
@@ -127,9 +117,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Cafe",
-              "name": "Brighton",
-              "formattedAddress": "4 Seville St, Brighton BN2 3AR, UK"
+              "store": "Josie's Cafe Brighton",
+              "storeFullAddress": "4 Seville St, Brighton BN2 3AR, UK"
           }
       },
       {
@@ -139,9 +128,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Cafe",
-              "name": "Newtown",
-              "formattedAddress": "13 Fron Hafren, Newtown SY16 2EJ, UK"
+              "store": "Josie's Cafe Newtown",
+              "storeFullAddress": "13 Fron Hafren, Newtown SY16 2EJ, UK"
           }
       },
       {
@@ -151,9 +139,8 @@
           },
           "type": "Feature",
           "properties": {
-              "banner": "Josie's Cafe",
-              "name": "Ipswich",
-              "formattedAddress": "147 Valley Rd, Ipswich IP1 4PQ, UK"
+              "store": "Josie's Cafe Ipswich",
+              "storeFullAddress": "147 Valley Rd, Ipswich IP1 4PQ, UK"
           }
       }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,9 +1188,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gocrisp/store-locator@file:../store-locator/gocrisp-store-locator-v0.4.0.tgz":
+"@gocrisp/store-locator@^0.4.0":
   version "0.4.0"
-  resolved "file:../store-locator/gocrisp-store-locator-v0.4.0.tgz#a9089bb8825aa34cb48c34dfe560323b7a21397c"
+  resolved "https://registry.yarnpkg.com/@gocrisp/store-locator/-/store-locator-0.4.0.tgz#8894b5b503767ddb7de978618557c88ca281bb35"
+  integrity sha512-yOAyFzkPUfAkK5uFSzgSgQhBCbLeurV2OajNemwHnoIUwbdbAkrCldClutoMnuUmtjD7dyOdJ6Bh5BwkSzvE6g==
   dependencies:
     "@googlemaps/js-api-loader" "^1.11.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,10 +1188,9 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gocrisp/store-locator@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@gocrisp/store-locator/-/store-locator-0.2.0.tgz#7f5e17d61d103199517d7e81c14233d9c5ccfd9a"
-  integrity sha512-RcGE/3NrVSYROPU6Zhu63XtBPA8d74vFAsHwDIQEZwwFQYJaZIanXtAk8eE60vDukMC33A+YVr/GmK2ifm/D+Q==
+"@gocrisp/store-locator@file:../store-locator/gocrisp-store-locator-v0.4.0.tgz":
+  version "0.4.0"
+  resolved "file:../store-locator/gocrisp-store-locator-v0.4.0.tgz#a9089bb8825aa34cb48c34dfe560323b7a21397c"
   dependencies:
     "@googlemaps/js-api-loader" "^1.11.3"
 
@@ -2048,7 +2047,7 @@ array-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
-array-includes@^3.1.1:
+array-includes@^3.1.1, array-includes@^3.1.2, array-includes@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.3.tgz#c7f619b382ad2afaf5326cddfdc0afc61af7690a"
   integrity sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==
@@ -2077,6 +2076,16 @@ array.prototype.flat@^1.2.3:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
+
+array.prototype.flatmap@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz#94cfd47cc1556ec0747d97f7c7738c58122004c9"
+  integrity sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    function-bind "^1.1.1"
 
 asn1.js@^5.2.0:
   version "5.4.1"
@@ -3430,6 +3439,13 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -3774,6 +3790,29 @@ eslint-plugin-promise@^4.2.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz#61485df2a359e03149fdafc0a68b0e030ad2ac45"
   integrity sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==
+
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
+eslint-plugin-react@^7.23.2:
+  version "7.23.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.23.2.tgz#2d2291b0f95c03728b55869f01102290e792d494"
+  integrity sha512-AfjgFQB+nYszudkxRkTFu0UR1zEQig0ArVMPloKhxwlwkzaw/fBiH0QWcBBhZONlXqQC51+nfqFrkn4EzHcGBw==
+  dependencies:
+    array-includes "^3.1.3"
+    array.prototype.flatmap "^1.2.4"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.4.1 || ^3.0.0"
+    minimatch "^3.0.4"
+    object.entries "^1.1.3"
+    object.fromentries "^2.0.4"
+    object.values "^1.1.3"
+    prop-types "^15.7.2"
+    resolve "^2.0.0-next.3"
+    string.prototype.matchall "^4.0.4"
 
 eslint-plugin-testing-library@^3.10.1:
   version "3.10.2"
@@ -4295,7 +4334,7 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -4780,6 +4819,15 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
+internal-slot@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
+  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
+  dependencies:
+    get-intrinsic "^1.1.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -5689,6 +5737,14 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+"jsx-ast-utils@^2.4.1 || ^3.0.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz#41108d2cec408c3453c1bbe8a4aae9e1e2bd8f82"
+  integrity sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==
+  dependencies:
+    array-includes "^3.1.2"
+    object.assign "^4.1.2"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -5845,7 +5901,7 @@ log-symbols@^2.2.0:
   dependencies:
     chalk "^2.0.1"
 
-loose-envify@^1.1.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -6346,6 +6402,26 @@ object.assign@^4.1.0, object.assign@^4.1.2:
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
 
+object.entries@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.3.tgz#c601c7f168b62374541a07ddbd3e2d5e4f7711a6"
+  integrity sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    has "^1.0.3"
+
+object.fromentries@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.4.tgz#26e1ba5c4571c5c6f0890cef4473066456a120b8"
+  integrity sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.2"
+    has "^1.0.3"
+
 object.getownpropertydescriptors@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz#1bd63aeacf0d5d2d2f31b5e393b03a7c601a23f7"
@@ -6362,7 +6438,7 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-object.values@^1.1.0, object.values@^1.1.1:
+object.values@^1.1.0, object.values@^1.1.1, object.values@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.3.tgz#eaa8b1e17589f02f698db093f7c62ee1699742ee"
   integrity sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==
@@ -7311,6 +7387,15 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -7423,6 +7508,11 @@ react-dom@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-is@^16.8.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-is@^17.0.1:
   version "17.0.2"
@@ -7553,6 +7643,14 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexp.prototype.flags@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
+  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
@@ -7703,6 +7801,14 @@ resolve@^1.1.5, resolve@^1.10.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  dependencies:
+    is-core-module "^2.2.0"
+    path-parse "^1.0.6"
+
+resolve@^2.0.0-next.3:
+  version "2.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.3.tgz#d41016293d4a8586a39ca5d9b5f15cbea1f55e46"
+  integrity sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==
   dependencies:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
@@ -8044,6 +8150,15 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
@@ -8312,6 +8427,19 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string.prototype.matchall@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz#608f255e93e072107f5de066f81a2dfb78cf6b29"
+  integrity sha512-pknFIWVachNcyqRfaQSeu/FUfpvJTe4uskUSZ9Wc1RijsPuzbZ8TyYT8WCNnntCjUEqQ3vUHMAfVj2+wLAisPQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.2"
+    has-symbols "^1.0.1"
+    internal-slot "^1.0.3"
+    regexp.prototype.flags "^1.3.1"
+    side-channel "^1.0.4"
 
 string.prototype.trimend@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This wound up being a few different updates in one PR, mostly just rolling up all of the recent changes in `store-locator` into this component as well:

1. Added react plugins for eslint - I noticed that I wasn't getting the react hooks warnings (I originally had an extra `useEffect` for loading, which is gone now)
2. Updated the `sample.json` and example to match the new data format from BYT-662
3. Bumped version to match `store-locator`. I'm not sure if this is how we want to do it in the future, but as long as we don't wind up bumping the version on this one without any changes all the time, I think it's nice to have them match so we know how they go together.

There were originally more changes to handle loading google maps conditionally, but that all got reverted since the `store-locator` is now auto-detecting whether we've loaded it already or not.

Note, yarn.lock will need to be updated once [this PR](https://github.com/gocrisp/store-locator/pull/14) is merged.