### PR TITLE
BYT-698: public repo polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ dist/
 coverage/
 
 .idea/
+.env.local

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -5,7 +5,7 @@ import { StoreLocator } from '../src';
 const App = () => (
   <StoreLocator
     geoJson="./sample.json"
-    loaderOptions={{ apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk' }}
+    loaderOptions={{ apiKey: process.env.GOOGLE_MAPS_API_KEY as string }}
     style={{ margin: 'auto' }}
     mapOptions={{ center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 }}
     formatLogoPath={feature =>

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "ts-jest": "^26.5.4",
     "typescript": "^4.0.3"
   },
+  "resolutions": {
+    "is-svg": ">=4.2.2"
+  },
   "scripts": {
     "build": "microbundle -o dist/ --sourcemap false --compress false --jsx React.createElement --external react",
     "dev": "microbundle watch -o dist/ --sourcemap false --compress false",

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -7,7 +7,7 @@ import { StoreLocator } from '../index';
 jest.mock('@gocrisp/store-locator');
 
 const options = {
-  loaderOptions: { apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk' },
+  loaderOptions: { apiKey: 'api-key' },
   geoJson: 'https://platform.gocrisp.com/geojson.json',
   mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
   formatLogoPath: (feature: google.maps.Data.Feature) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4137,6 +4137,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-xml-parser@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
+  integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
+
 fastparse@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
@@ -4619,11 +4624,6 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
-html-comment-regex@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
-  integrity sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==
-
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -5093,12 +5093,12 @@ is-string@^1.0.5:
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
 
-is-svg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-3.0.0.tgz#9321dbd29c212e5ca99c4fa9794c714bcafa2f75"
-  integrity sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==
+is-svg@>=4.2.2, is-svg@^3.0.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-4.3.1.tgz#8c63ec8c67c8c7f0a8de0a71c8c7d58eccf4406b"
+  integrity sha512-h2CGs+yPUyvkgTJQS9cJzo9lYK06WgRiXUqBBHtglSzVKAuH4/oWsqk7LGfbSa1hGk9QcZ0SyQtVggvBA8LZXA==
   dependencies:
-    html-comment-regex "^1.1.0"
+    fast-xml-parser "^3.19.0"
 
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Same as [this](https://github.com/gocrisp/store-locator/pull/15), but without deployment concerns 🙂

Also adding the resolution for `is-svg` since this finally got the same dependabot alert that we already addressed in `store-locator` - we really aren't using that dependency's functionality AND it's a dev dependency (from parcel), so it shouldn't affect anything.