### PR TITLE
BYT-710: Updated store-locator version and exposed more options

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,3 +1,4 @@
+import { StoreLocatorMap } from '@gocrisp/store-locator';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { StoreLocator } from '../src';
@@ -23,6 +24,12 @@ const App = () => (
       autocompleteOptions: {
         componentRestrictions: { country: 'gb' },
       },
+    }}
+    onMapInit={({ map, infoWindow, autocomplete, originMarker }: StoreLocatorMap) => {
+      console.log(map);
+      console.log(infoWindow);
+      console.log(autocomplete);
+      console.log(originMarker);
     }}
   />
 );

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -25,11 +25,12 @@ const App = () => (
         componentRestrictions: { country: 'gb' },
       },
     }}
-    onMapInit={({ map, infoWindow, autocomplete, originMarker }: StoreLocatorMap) => {
+    onMapInit={({ map, infoWindow, autocomplete, originMarker, storeList }: StoreLocatorMap) => {
       console.log(map);
       console.log(infoWindow);
       console.log(autocomplete);
       console.log(originMarker);
+      console.log(storeList);
     }}
   />
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gocrisp/react-store-locator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "React component for Crisp's store locator widget, intended for use with the Crisp GeoJSON connector.",
   "main": "dist/react-store-locator.js",
   "umd:main": "dist/react-store-locator.umd.js",
@@ -11,7 +11,7 @@
     "readme.md"
   ],
   "dependencies": {
-    "@gocrisp/store-locator": "^0.4.0",
+    "@gocrisp/store-locator": "^0.5.0",
     "@googlemaps/js-api-loader": "^1.11.3"
   },
   "devDependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,9 @@ export type StoreLocatorProps = Omit<StoreLocatorOptions, 'container'> & {
   onMapInit?: (storeLocatorMap: StoreLocatorMap) => void;
 };
 
+// Re-export type so it is visible when using this package
+export { StoreLocatorMap } from '@gocrisp/store-locator';
+
 export const StoreLocator: React.VFC<StoreLocatorProps> = ({
   onMapInit = () => {},
   className,
@@ -23,6 +26,7 @@ export const StoreLocator: React.VFC<StoreLocatorProps> = ({
   infoWindowOptions,
   formatLogoPath,
   searchBoxOptions,
+  storeListOptions,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -36,6 +40,7 @@ export const StoreLocator: React.VFC<StoreLocatorProps> = ({
         infoWindowOptions,
         formatLogoPath,
         searchBoxOptions,
+        storeListOptions,
       })
         .then(onMapInit)
         .catch(err => console.error('Could not initialize store locator map.', err));
@@ -47,6 +52,7 @@ export const StoreLocator: React.VFC<StoreLocatorProps> = ({
     infoWindowOptions,
     mapOptions,
     searchBoxOptions,
+    storeListOptions,
     onMapInit,
   ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,9 +1188,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gocrisp/store-locator@/Users/jengettings/src/store-locator/gocrisp-store-locator-v0.4.4.tgz":
-  version "0.4.4"
-  resolved "/Users/jengettings/src/store-locator/gocrisp-store-locator-v0.4.4.tgz#b47f94288dd1dac7e67e1001635d11b3351d5543"
+"@gocrisp/store-locator@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@gocrisp/store-locator/-/store-locator-0.5.0.tgz#cb94541bec3044a97cdd9aa8d8017b9731612c3b"
+  integrity sha512-qdJ2Sn292IQENnjWddX0+tRDwmpTUb/69ATv6Ykqo1nKEBYAFx2fg0lc8r1Jo9Yvqs2xFEuk/GiEKVb3HqAw2A==
   dependencies:
     "@googlemaps/js-api-loader" "^1.11.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,10 +1188,9 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gocrisp/store-locator@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@gocrisp/store-locator/-/store-locator-0.4.0.tgz#8894b5b503767ddb7de978618557c88ca281bb35"
-  integrity sha512-yOAyFzkPUfAkK5uFSzgSgQhBCbLeurV2OajNemwHnoIUwbdbAkrCldClutoMnuUmtjD7dyOdJ6Bh5BwkSzvE6g==
+"@gocrisp/store-locator@/Users/jengettings/src/store-locator/gocrisp-store-locator-v0.4.4.tgz":
+  version "0.4.4"
+  resolved "/Users/jengettings/src/store-locator/gocrisp-store-locator-v0.4.4.tgz#b47f94288dd1dac7e67e1001635d11b3351d5543"
   dependencies:
     "@googlemaps/js-api-loader" "^1.11.3"
 


### PR DESCRIPTION
*Note: yarn.lock will need to be updated once the new version of `store-locator` is live

We needed access to the `StoreLocatorMap` type and it was not exposed yet.

The `storeListOptions` should've been in here, but it was missed when that was added.